### PR TITLE
correção de footer e tabelas em resoluções menores

### DIFF
--- a/sapl/static/styles/app.scss
+++ b/sapl/static/styles/app.scss
@@ -201,23 +201,23 @@ html {
 body {
   margin-bottom: $footer-height + 20px;
 }
-.footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  /* Set the fixed height of the footer here */
-  height: $footer-height;
-  background: #364347 none repeat scroll 0% 0%;
-  color: white;
-  text-align: center;
-  p {
-    color: white;
-    margin-top: 10px;
-  }
-  .container {
-    padding-top: 25px;
-  }
-}
+.footer{
+    position:absolute;
+    width:100%;
+    background:#364347 none repeat scroll 0% 0%;
+    color:white;
+    text-align:center;
+    margin-top:20px;
+}  
+
+ .footer p{
+     color:white;
+     margin-top:10px;
+ }
+
+.footer .container{
+    padding-top:25px;
+ }
 
 label {
   margin-bottom: 0;
@@ -571,6 +571,14 @@ p {
   }
 }
 
+@media screen and (max-width: 512px) {
+    .table{
+        width: auto;
+        white-space: normal;
+        display:block;
+        overflow-x: auto;
+    }
+}
 
 @media (max-width: 1199px) {
   .masthead {


### PR DESCRIPTION
### Descrição
São pequenas alterações de estilo dentro de app.css
### Mudanças:

1) Na classe .footer (Remoção das propriedades bottom e width e adição de margin-top
2) Adicão de media querie para resolução de 512px

### Issue Relacionada
#2272
#2275

### Motivação e Contexto

1. Corrigir a quebra de fluxo do background no rodapé com resoluções abaixo de 992px;
2. Exibição adequada de tabelas em resoluções menores que 512px